### PR TITLE
[DevOps] GitHub Actions CI 설정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,5 +35,6 @@ jobs:
         cache-cleanup: on-success
 
     - name: Test with Gradle Wrapper
-      run: gradle test
+      working-directory: ./backend
+      run: ./gradlew test
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,39 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on:
+  pull_request:
+    types: [review_requested]
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
+    # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
+    # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      with:
+        cache-cleanup: on-success
+
+    - name: Test with Gradle Wrapper
+      run: ./gradlew test
+

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,7 +13,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
     permissions:
@@ -34,7 +34,7 @@ jobs:
       with:
         cache-cleanup: on-success
 
-    - name: Test with Gradle Wrapper
+    - name: Test with Gradle
       working-directory: ./backend
       run: gradle test
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,5 +36,5 @@ jobs:
 
     - name: Test with Gradle Wrapper
       working-directory: ./backend
-      run: ./gradlew test
+      run: gradle test
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,5 +35,5 @@ jobs:
         cache-cleanup: on-success
 
     - name: Test with Gradle Wrapper
-      run: ./gradlew test
+      run: gradle test
 

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/flicktionary
-    username: root
-    password: lldj123414
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
 
   jpa:
     hibernate:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/flicktionary
+    username: root
+    password: lldj123414
+
+  jpa:
+    hibernate:
+      ddl-auto: update

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -1,23 +1,18 @@
-#spring:
-#  datasource:
-#    url: jdbc:mysql://localhost:3306/flicktionary
-
-#김형준
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/flicktionary
+    url: jdbc:h2:mem:db_test;MODE=MySQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+    hikari:
+      auto-commit: false
+  jpa:
+    hibernate:
+      ddl-auto: create
 
-#김형준
-#spring:
-#  datasource:
-#    url: jdbc:mysql://localhost:3307/test?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
-#    driver-class-name: com.mysql.cj.jdbc.Driver
-#    username: root
-#    password: 1234
-
-#    url: jdbc:h2:mem:db_test;MODE=MySQL
-#    username: sa
-#    password:
-#    driver-class-name: org.h2.Driver
-#    hikari:
-#      auto-commit: false
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE
+    org.hibernate.orm.jdbc.extract: TRACE
+    org.springframework.transaction.interceptor: TRACE

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -2,30 +2,14 @@ server:
   port: 8080
 
 spring:
-  config:
-    import: classpath:application-apikey.yml
-
   output:
     ansi:
       enabled: always
-
-  profiles:
-    active: dev
-#    include: test
-
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/flicktionary
-    username: root
-    password: lldj123414
 
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQLDialect
     open-in-view: false
-    hibernate:
-      ddl-auto: update
-#      ddl-auto: create
     show-sql: false
     properties:
       hibernate:
@@ -34,12 +18,10 @@ spring:
         use_sql_comments: true
         default_batch_fetch_size: 10
 
-logging:
-  level:
-    org.hibernate.SQL: DEBUG
-    org.hibernate.orm.jdbc.bind: TRACE
-    org.hibernate.orm.jdbc.extract: TRACE
-    org.springframework.transaction.interceptor: TRACE
+
+tmdb:
+  access-token: ${TMDB_ACCESS_TOKEN}
+  base-image-url: ${TMDB_BASE_IMAGE_URL}
 
 custom:
   jwt:


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
GitHub Actions로 CI 설정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
`main` 브랜치로의 PR에서 리뷰를 요청하면 GitHub Actions에서 `./gradlew test`로 테스트를 실행한다.
애플리케이션 설정을 `prod`와 `test` 두 종류로 나누고, `prod`에서는 로컬 MySQL 인스턴스를, `test`에서는 in-memory모드로 구동되는 H2 인스턴스를 DB로 사용한다.
TMDB API키를 다른 설정 파일에서 받아오는 대신 `application.yml`에서 환경 변수로 받아오게끔 변경.