### PR TITLE
[UserAccount] 로그인 및 회원가입 페이지 구현

### DIFF
--- a/backend/src/main/java/com/example/Flicktionary/domain/user/controller/UserAccountController.java
+++ b/backend/src/main/java/com/example/Flicktionary/domain/user/controller/UserAccountController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 /**
  * 회원 도메인에 해당하는 API 엔드포인트
  */
+// TODO: ResponseEntity<String> 대신 JSON을 반환하게끔 수정
 @RequestMapping("/api/users")
 @RestController
 @RequiredArgsConstructor
@@ -160,6 +161,7 @@ public class UserAccountController {
      * @param value 쿠키의 값
      * @return 새 쿠키 오브젝트
      */
+    // TODO: Expires / Max-Age 설정 추가
     private Cookie newCookieWithDefaultSettings(String name, String value) {
         Cookie cookie = new Cookie(name, value == null ? "" : value);
         cookie.setHttpOnly(true);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-select": "^2.1.6",
         "@radix-ui/react-slot": "^1.1.2",
         "class-variance-authority": "^0.7.1",
@@ -1055,6 +1056,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.2.tgz",
+      "integrity": "sha512-zo1uGMTaNlHehDyFQcDZXRJhUPDuukcnHz0/jnrup0JA6qL+AFpAnty+7VKa9esuU5xTblAZzTGYJKSKaBxBhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-slot": "^1.1.2",
     "class-variance-authority": "^0.7.1",

--- a/frontend/src/app/login/login-form.tsx
+++ b/frontend/src/app/login/login-form.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import client from "@/lib/backend/client";
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+export function LoginForm({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+
+  async function login(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const form = e.target as HTMLFormElement
+    const data = {
+      username: form.username.value,
+      password: form.password.value
+    }
+    const response = await client.POST("/api/users/login", {body: data, credentials: "include"})
+    if (response.error) {
+      alert('[' + response['error']['status'] + '] ' + response['error']['message'])
+      return
+    }
+    // show success message and redirect to main page
+    alert(response.data)
+    window.location.href = "/";
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-6", className)} {...props}>
+      <Card>
+        <CardHeader>
+          <CardTitle>로그인</CardTitle>
+          <CardDescription>
+          로그인을 위해 ID와 비밀번호를 입력해주세요.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={login}>
+            <div className="flex flex-col gap-6">
+              <div className="grid gap-3">
+                <Label htmlFor="username">유저 ID</Label>
+                <Input
+                  id="username"
+                  type="username"
+                  placeholder="유저 ID"
+                  required
+                />
+              </div>
+              <div className="grid gap-3">
+                <div className="flex items-center">
+                  <Label htmlFor="password">비밀번호</Label>
+                </div>
+                <Input id="password" type="password" placeholder="비밀번호" required />
+              </div>
+              <div className="flex flex-col gap-3">
+                <Button type="submit" className="w-full">
+                  로그인
+                </Button>
+              </div>
+            </div>
+            <div className="mt-4 text-center text-sm">
+              계정이 없으신가요?{" "}
+              <a href="/signup" className="underline underline-offset-4">
+                회원가입
+              </a>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,11 @@
+import { LoginForm } from "./login-form"
+
+export default function Page() {
+  return (
+    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
+      <div className="w-full max-w-sm">
+        <LoginForm />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -1,0 +1,11 @@
+import { SignupForm } from "./signup-form"
+
+export default function Page() {
+  return (
+    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
+      <div className="w-full max-w-sm">
+        <SignupForm />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/signup/signup-form.tsx
+++ b/frontend/src/app/signup/signup-form.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import client from "@/lib/backend/client";
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+export function SignupForm({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+
+  async function register(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const form = e.target as HTMLFormElement
+    const data = {
+      username: form.username.value,
+      password: form.password.value,
+      email: form.email.value,
+      nickname: form.nickname.value
+    }
+    const response = await client.POST("/api/users/register", {body: data, credentials: "include"})
+    if (response.error) {
+      alert(response['error']['msg'])
+      return
+    }
+    // show success message and redirect to login page
+    alert(response.data)
+    window.location.href = "/login";
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-6", className)} {...props}>
+      <Card>
+        <CardHeader>
+          <CardTitle>회원가입</CardTitle>
+          <CardDescription>
+          회원가입을 위해 가입 정보를 입력해주세요.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={register}>
+            <div className="flex flex-col gap-6">
+              <div className="grid gap-3">
+                <Label htmlFor="username">유저 ID</Label>
+                <Input
+                  id="username"
+                  type="username"
+                  placeholder="유저 ID"
+                  required
+                />
+              </div>
+              <div className="grid gap-3">
+                <div className="flex items-center">
+                  <Label htmlFor="password">비밀번호</Label>
+                </div>
+                <Input id="password" type="password" placeholder="비밀번호" required />
+              </div>
+              <div className="grid gap-3">
+                <Label htmlFor="email">이메일</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="email@flicktionary.com"
+                  required
+                />
+              </div>
+              <div className="grid gap-3">
+                <Label htmlFor="nickname">닉네임</Label>
+                <Input
+                  id="nickname"
+                  type="nickname"
+                  placeholder="닉네임"
+                  required
+                />
+              </div>
+              <div className="flex flex-col gap-3">
+                <Button type="submit" className="w-full">
+                가입하기
+                </Button>
+              </div>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
FE에 회원 로그인 및 가입 페이지 추가

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
`/login`에 로그인 페이지를, `/signup`에 회원가입 페이지를 구현.
BE단에서 개선이 필요한 곳이 몇 군데 있어 보여서 관련 코드에 TODO 주석으로 개선사항을 추가.

Closes #77.