### PR TITLE
[UserAccount] 쿠키 속성 추가

### DIFF
--- a/backend/src/main/java/com/example/Flicktionary/domain/user/controller/UserAccountController.java
+++ b/backend/src/main/java/com/example/Flicktionary/domain/user/controller/UserAccountController.java
@@ -161,12 +161,13 @@ public class UserAccountController {
      * @param value 쿠키의 값
      * @return 새 쿠키 오브젝트
      */
-    // TODO: Expires / Max-Age 설정 추가
     private Cookie newCookieWithDefaultSettings(String name, String value) {
         Cookie cookie = new Cookie(name, value == null ? "" : value);
         cookie.setHttpOnly(true);
         cookie.setDomain("localhost");
         cookie.setPath("/");
+        // 300일 후 쿠키 만료
+        cookie.setMaxAge(25920000);
         cookie.setAttribute("SameSite", "Strict");
         return cookie;
     }

--- a/backend/src/test/java/com/example/Flicktionary/domain/user/controller/UserAccountControllerTest.java
+++ b/backend/src/test/java/com/example/Flicktionary/domain/user/controller/UserAccountControllerTest.java
@@ -98,10 +98,13 @@ class UserAccountControllerTest {
                                 .contentType("application/json")
                                 .characterEncoding("UTF-8"))
                 .andExpect(status().isOk())
+                // TODO: 매번 쿠키 설정을 assert하는 대신 전용 테스트 케이스로 분리. 관련 메소드가 private이기 때문에 UserAccountController.logoutUser 메소드를 사용하면 될 듯.
                 .andExpect(cookie().value("accessToken", "fakeAccessToken"))
                 .andExpect(cookie().httpOnly("accessToken", true))
+                .andExpect(cookie().maxAge("accessToken", 25920000))
                 .andExpect(cookie().value("refreshToken", "fakeRefreshToken"))
                 .andExpect(cookie().httpOnly("refreshToken", true))
+                .andExpect(cookie().maxAge("refreshToken", 25920000))
                 .andExpect(content().string("토큰이 성공적으로 발행되었습니다."));
 
         then(userAccountJwtAuthenticationService).should()
@@ -119,8 +122,10 @@ class UserAccountControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(cookie().value("accessToken", ""))
                 .andExpect(cookie().httpOnly("accessToken", true))
+                .andExpect(cookie().maxAge("accessToken", 25920000))
                 .andExpect(cookie().value("refreshToken", ""))
                 .andExpect(cookie().httpOnly("refreshToken", true))
+                .andExpect(cookie().maxAge("refreshToken", 25920000))
                 .andExpect(content().string("쿠키가 성공적으로 비워졌습니다."));
     }
 
@@ -137,8 +142,10 @@ class UserAccountControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(cookie().value("accessToken", "fakeAccessToken"))
                 .andExpect(cookie().httpOnly("accessToken", true))
+                .andExpect(cookie().maxAge("accessToken", 25920000))
                 .andExpect(cookie().value("refreshToken", "fakeRefreshToken"))
                 .andExpect(cookie().httpOnly("refreshToken", true))
+                .andExpect(cookie().maxAge("refreshToken", 25920000))
                 .andExpect(content().string("토큰이 성공적으로 재발행되었습니다."));
 
         then(userAccountJwtAuthenticationService).should()


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
인증 쿠키에 `Max-Age` 속성 추가

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
`Cookie` 오브젝트의 `Max-Age` 기본값은 `0`인데, 이렇게 되면 다음 요청때 쿠키가 바로 삭제된다. 이를 방지하기 위해 `Max-Age` 설정값을 추가해 임의의 기간동안(300일) 쿠키가 유지되도록 변경.
쿠키 속성의 추가에 맞춰 테스트 케이스 최신화.

Closes #104.