### PR TITLE
[BE] 인증 기능 개선 및 고도화

### DIFF
--- a/backend/src/main/java/com/example/Flicktionary/domain/user/controller/UserAccountController.java
+++ b/backend/src/main/java/com/example/Flicktionary/domain/user/controller/UserAccountController.java
@@ -58,6 +58,7 @@ public class UserAccountController {
      */
     @PostMapping("/login")
     public ResponseEntity<ResponseDto<?>> loginUser(@RequestBody LoginRequest loginRequest, HttpServletResponse response) {
+        // DB 접근을 1회 줄이기 위해 아래 UserAccountJwtAuthenticationService의 두 메서드를 하나로 합치는 것을 검토
         Cookie accessToken = newCookieWithDefaultSettings("accessToken", userAccountJwtAuthenticationService.createNewAccessTokenForUser(loginRequest.username, loginRequest.password));
         Cookie refreshToken = newCookieWithDefaultSettings("refreshToken", userAccountJwtAuthenticationService.rotateRefreshTokenOfUser(loginRequest.username));
         response.addCookie(accessToken);

--- a/backend/src/main/java/com/example/Flicktionary/domain/user/service/UserAccountJwtAuthenticationService.java
+++ b/backend/src/main/java/com/example/Flicktionary/domain/user/service/UserAccountJwtAuthenticationService.java
@@ -6,6 +6,7 @@ import com.example.Flicktionary.global.utils.JwtUtils;
 import com.example.Flicktionary.global.utils.UuidUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +23,8 @@ import java.util.UUID;
 public class UserAccountJwtAuthenticationService {
 
     private final UserAccountRepository userAccountRepository;
+
+    private final PasswordEncoder passwordEncoder;
 
     /**
      * JWT 서명/검증에 사용될 비밀키
@@ -49,7 +52,7 @@ public class UserAccountJwtAuthenticationService {
      */
     public String createNewAccessTokenForUser(String username, String password) {
         UserAccount userAccount = getUserByUsername(username);
-        if (!userAccount.getPassword().equals(password)) {
+        if (!passwordEncoder.matches("{bcrypt}" + password, userAccount.getPassword())) {
             throw new RuntimeException("비밀번호가 틀립니다.");
         }
         return createNewAccessTokenWithClaims(userAccount.getUsername(), userAccount.getNickname());

--- a/backend/src/main/java/com/example/Flicktionary/domain/user/service/UserAccountService.java
+++ b/backend/src/main/java/com/example/Flicktionary/domain/user/service/UserAccountService.java
@@ -5,6 +5,7 @@ import com.example.Flicktionary.domain.user.entity.UserAccount;
 import com.example.Flicktionary.domain.user.entity.UserAccountType;
 import com.example.Flicktionary.domain.user.repository.UserAccountRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,13 +19,17 @@ public class UserAccountService {
 
     private final UserAccountRepository userAccountRepository;
 
+    private final PasswordEncoder passwordEncoder;
+
     /**
      * 새 회원을 생성한 뒤 영속한다.
      * @param userAccountDto 새로 생성할 회원의 정보가 담긴 DTO
      * @return 영속된 회원에 해당하는 DTO
      */
     public UserAccountDto registerUser(UserAccountDto userAccountDto) {
-        return UserAccountDto.from(userAccountRepository.save(userAccountDto.toEntity()));
+        UserAccount userAccount = userAccountDto.toEntity();
+        userAccount.setPassword(passwordEncoder.encode("{bcrypt}" + userAccount.getPassword()));
+        return UserAccountDto.from(userAccountRepository.save(userAccount));
     }
 
     /**
@@ -37,7 +42,7 @@ public class UserAccountService {
         UserAccount userAccount = userAccountRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
         userAccount.setUsername(userAccountDto.username());
-        userAccount.setPassword(userAccountDto.password());
+        userAccount.setPassword(passwordEncoder.encode("{bcrypt}" + userAccountDto.password()));
         userAccount.setEmail(userAccountDto.email());
         userAccount.setNickname(userAccountDto.nickname());
         userAccount.setRole(UserAccountType.valueOf(userAccountDto.role()));

--- a/backend/src/main/java/com/example/Flicktionary/global/security/PasswordEncoderConfig.java
+++ b/backend/src/main/java/com/example/Flicktionary/global/security/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.example.Flicktionary.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/com/example/Flicktionary/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/example/Flicktionary/global/security/SecurityConfig.java
@@ -10,7 +10,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
@@ -51,7 +50,7 @@ public class SecurityConfig {
                                             response.getWriter().write(
                                                     objectMapper.writeValueAsString(ResponseDto.of(
                                                             HttpStatus.FORBIDDEN.value() + "",
-                                                            "인증 토큰이 잘못되었거나 로그인이 필요합니다."
+                                                            "로그인이 필요합니다."
                                                     )));
                                         }
                                 )

--- a/backend/src/test/java/com/example/Flicktionary/domain/user/service/UserAccountJwtAuthenticationServiceTest.java
+++ b/backend/src/test/java/com/example/Flicktionary/domain/user/service/UserAccountJwtAuthenticationServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -46,6 +47,9 @@ class UserAccountJwtAuthenticationServiceTest {
     @Mock
     private UserAccountRepository userAccountRepository;
 
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
     @InjectMocks
     private UserAccountJwtAuthenticationService userAccountJwtAuthenticationService;
 
@@ -69,6 +73,7 @@ class UserAccountJwtAuthenticationServiceTest {
     @Test
     void givenCorrectUserCredentialsWhenCreatingTokenThenReturnTokenWithCorrectClaims() {
         given(userAccountRepository.findByUsername(anyString())).willReturn(Optional.of(userAccount));
+        given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
 
         String token = userAccountJwtAuthenticationService.createNewAccessTokenForUser(
                 userAccount.getUsername(),

--- a/backend/src/test/java/com/example/Flicktionary/domain/user/service/UserAccountServiceTest.java
+++ b/backend/src/test/java/com/example/Flicktionary/domain/user/service/UserAccountServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
@@ -17,6 +18,7 @@ import static org.assertj.core.api.BDDAssertions.catchThrowable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
@@ -36,6 +38,9 @@ class UserAccountServiceTest {
     @Mock
     private UserAccountRepository userAccountRepository;
 
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
     @InjectMocks
     private UserAccountService userAccountService;
 
@@ -44,6 +49,7 @@ class UserAccountServiceTest {
     void givenDtoWhenRegisteringUserWillPersistUserAccount() {
         given(userAccountRepository.save(any(UserAccount.class)))
                 .willReturn(userAccountDto.toEntity());
+        given(passwordEncoder.encode(anyString())).willReturn(userAccountDto.password());
 
         UserAccountDto resUserAccountDto = userAccountService.registerUser(userAccountDto);
 
@@ -85,6 +91,7 @@ class UserAccountServiceTest {
                 .willReturn(Optional.of(userAccountDto.toEntity()));
         given(userAccountRepository.save(any(UserAccount.class)))
                 .willReturn(newUserAccountDto.toEntity());
+        given(passwordEncoder.encode(anyString())).willReturn(newUserAccountDto.password());
 
         UserAccountDto result = userAccountService.modifyUser(
                 userAccountDto.id(),


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
Spring Security를 통한 인증 기능을 개선한다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
**접근 토큰**의 검증이 실패하면, `CustomAuthenticationFilter`에서 토큰 재발급을 위해 `/api/users/refresh`로 리다이렉팅 한다.
평문으로 저장되던 비밀번호를 `bcrypt` 알고리즘으로 암호화한다.

Closes #128.